### PR TITLE
Improvements to CLI to add support for STDIN/OUT 

### DIFF
--- a/lib/language/cli.js
+++ b/lib/language/cli.js
@@ -15,9 +15,10 @@ exports.main = function(args)
         input = options.input,
         output = options.output;
 
-    if (!grammar || !grammar.length)
+    if ((!grammar || !grammar.length) && (input !== undefined && !input.length))
     {
-        console.log('Grammar via stdin:');
+        console.error("The grammar and input can not both come from stdin.");
+        process.exit(1);
     }
 
     read(grammar, function(err, data) {
@@ -30,11 +31,6 @@ exports.main = function(args)
 
         if (input !== undefined)
         {
-            if (!input.length)
-            {
-                console.log('Input via stdin:');
-            }
-
             read(input, function(err, data) {
                 if (err)
                 {
@@ -109,9 +105,7 @@ function read(filename, callback)
         stdin.resume();
         stdin.on('data', function(chunk) {
             lines += chunk.toString();
-            process.stdout.write('> ');
         }).on('end',function() {
-            process.stdout.write('\n');
             callback(false, lines);
         }).on('error', function() {
             console.error("There was an error while taking input data from stdin.");

--- a/lib/language/cli.js
+++ b/lib/language/cli.js
@@ -14,42 +14,62 @@ exports.main = function(args)
         grammar = options.grammar,
         input = options.input;
 
-    if (!options.grammar && !options.input)
+    if (!grammar && (!input || input === true))
     {
-        print("Grammar and input can't both implicitly be stdin.");
+        console.error("Grammar and input can't both implicitly be stdin.");
         process.exit(1);
     }
 
-    var grammarContents = read(grammar || "-", "utf8"),
-        parser = new Parser(grammarContents),
-        result = "";
+    read(grammar || true, function(err, data) {
+        if (err)
+        {
+            console.error("The Grammar file '"+grammar+"' could not be read.");
+            process.exit(1);
+        }
+        var parser = new Parser(data);
 
-    if (input)
-        result = parser.parse(read(input)).toString();
-
-    else
-    {
-        var json = JSON.stringify(parser.compiledGrammar).toUnicodeEscapedString();
-
-        if (options.table)
-            result = json;
-
+        if (input !== undefined)
+        {
+            if (input !== true && !input.length)
+            {
+                console.error("No file name has been specified for the input. Please use '-i -' if you wish to use STDIN.")
+                process.exit(1);
+            }
+            read(input, function(err, data) {
+                if (err)
+                {
+                    console.error("The input file '"+input+"' could not be read.");
+                    process.exit(1);
+                }
+                var result = parser.parse(data).toString();
+                write(options.output || "-", result);
+            });
+        }
         else
         {
-            var directory = path.dirname(module.filename);
+            var json = JSON.stringify(parser.compiledGrammar).toUnicodeEscapedString();
 
-            if (options.browser)
-                result =    read(path.join(directory, "templates", "browser.js")).
-                            replace(/%{NAMESPACE}/g, options.browser);
+            if (options.table)
+                write(options.output || "-", json);
+
             else
-                result = read(path.join(directory, "templates", "node.js"));
+            {
+                var directory = path.dirname(module.filename),
+                    templatename = (options.browser) ? path.join(directory, "templates", "browser.js") : path.join(directory, "templates", "node.js");
 
-            result = result.replace(/%{PARSER}/g, read(path.join(directory, "parser.js")))
-            result = result.replace(/%{COMPILED_GRAMMAR}/g, json);
+                read(templatename, function(err, templatedata) {
+                    if (options.browser)
+                        templatedata = templatedata.replace(/%{NAMESPACE}/g, options.browser);
+
+                    read(path.join(directory, "parser.js"), function(err, parserjsdata) {
+                        templatedata = templatedata.replace(/%{PARSER}/g, parserjsdata)
+                        templatedata = templatedata.replace(/%{COMPILED_GRAMMAR}/g, json);
+                        write(options.output || "-", templatedata);
+                    });
+                });
+            }
         }
-    }
-
-    write(options.output || "-", result);
+    });
 }
 
 function parseOptions()
@@ -58,17 +78,17 @@ function parseOptions()
     {
         grammar:{
                     string: '-g PATH, --grammar=PATH',
-                    help:"A Language grammar file"
+                    help:"A Language grammar file."
                 },
 
         input:  {
                     string:"-i, --input=PATH",
-                    helo:"An input file to parse"
+                    help:"An input file to parse. Use '-i -' for stdin."
                 },
 
         output: {
                     string:"-o, --output=PATH",
-                    help:"An output file to save the result"
+                    help:"An output file to save the result. If ommited stdout is used."
                 },
 
         table:  {
@@ -79,24 +99,35 @@ function parseOptions()
     }).parseArgs();
 }
 
-function read(filename)
+function read(filename, callback)
 {
-    if (filename === "-")
+    if (filename === true)
     {
-        //stdin
+        var stdin = process.stdin,
+            lines = "";
+        process.stdout.write('Use Ctrl-D to stop input:\n> ');
+        stdin.resume();
+        stdin.on('data', function(chunk) {
+            lines += chunk.toString();
+            process.stdout.write('> ');
+        }).on('end',function() {
+            process.stdout.write('\n');
+            callback(false, lines);
+        }).on('error', function() {
+            console.error("There was an error while taking input data from stdin.");
+            process.exit(1);
+        });
     }
-
-    return require("fs").readFileSync(filename, "utf8");
+    else
+        require("fs").readFile(filename, "utf8", callback);
 }
 
 function write(filename, contents)
 {
     if (filename === "-")
-    {
-        //stdout
-    }
-
-    return require("fs").writeFileSync(filename, contents);
+        console.log("%s", contents);
+    else
+        require("fs").writeFileSync(filename, contents);
 }
 
 String.prototype.toUnicodeEscapedString = function()

--- a/lib/language/cli.js
+++ b/lib/language/cli.js
@@ -12,15 +12,15 @@ exports.main = function(args)
 {
     var options = parseOptions(),
         grammar = options.grammar,
-        input = options.input;
+        input = options.input,
+        output = options.output;
 
-    if (!grammar && (!input || input === true))
+    if (!grammar || !grammar.length)
     {
-        console.error("Grammar and input can't both implicitly be stdin.");
-        process.exit(1);
+        console.log('Grammar via stdin:');
     }
 
-    read(grammar || true, function(err, data) {
+    read(grammar, function(err, data) {
         if (err)
         {
             console.error("The Grammar file '"+grammar+"' could not be read.");
@@ -30,11 +30,11 @@ exports.main = function(args)
 
         if (input !== undefined)
         {
-            if (input !== true && !input.length)
+            if (!input.length)
             {
-                console.error("No file name has been specified for the input. Please use '-i -' if you wish to use STDIN.")
-                process.exit(1);
+                console.log('Input via stdin:');
             }
+
             read(input, function(err, data) {
                 if (err)
                 {
@@ -42,7 +42,7 @@ exports.main = function(args)
                     process.exit(1);
                 }
                 var result = parser.parse(data).toString();
-                write(options.output || "-", result);
+                write(output, result);
             });
         }
         else
@@ -50,7 +50,7 @@ exports.main = function(args)
             var json = JSON.stringify(parser.compiledGrammar).toUnicodeEscapedString();
 
             if (options.table)
-                write(options.output || "-", json);
+                write(output, json);
 
             else
             {
@@ -64,7 +64,7 @@ exports.main = function(args)
                     read(path.join(directory, "parser.js"), function(err, parserjsdata) {
                         templatedata = templatedata.replace(/%{PARSER}/g, parserjsdata)
                         templatedata = templatedata.replace(/%{COMPILED_GRAMMAR}/g, json);
-                        write(options.output || "-", templatedata);
+                        write(output, templatedata);
                     });
                 });
             }
@@ -78,17 +78,17 @@ function parseOptions()
     {
         grammar:{
                     string: '-g PATH, --grammar=PATH',
-                    help:"A Language grammar file."
+                    help:"A Language grammar file. Omit for input via stdin."
                 },
 
         input:  {
                     string:"-i, --input=PATH",
-                    help:"An input file to parse. Use '-i -' for stdin."
+                    help:"An input file to parse. Omit for input via stdin."
                 },
 
         output: {
                     string:"-o, --output=PATH",
-                    help:"An output file to save the result. If ommited stdout is used."
+                    help:"An output file to save the result. If omitted stdout is used."
                 },
 
         table:  {
@@ -101,7 +101,7 @@ function parseOptions()
 
 function read(filename, callback)
 {
-    if (filename === true)
+    if (!filename || !filename.length)
     {
         var stdin = process.stdin,
             lines = "";
@@ -124,10 +124,16 @@ function read(filename, callback)
 
 function write(filename, contents)
 {
-    if (filename === "-")
+    if (!filename || !filename.length)
         console.log("%s", contents);
     else
-        require("fs").writeFileSync(filename, contents);
+        require("fs").writeFile(filename, contents, function(err) {
+            if (err)
+            {
+                console.error("There was an error writing to file '"+filename+"'.");
+                process.exit(1);
+            }
+        });
 }
 
 String.prototype.toUnicodeEscapedString = function()

--- a/lib/language/cli.js
+++ b/lib/language/cli.js
@@ -74,12 +74,12 @@ function parseOptions()
     {
         grammar:{
                     string: '-g PATH, --grammar=PATH',
-                    help:"A Language grammar file. Omit for input via stdin."
+                    help:"A Language grammar file. Omit value for input via stdin, use Ctrl-D to exit input mode."
                 },
 
         input:  {
                     string:"-i, --input=PATH",
-                    help:"An input file to parse. Omit for input via stdin."
+                    help:"An input file to parse. Omit value for input via stdin, use Ctrl-D to exit input mode."
                 },
 
         output: {
@@ -101,7 +101,6 @@ function read(filename, callback)
     {
         var stdin = process.stdin,
             lines = "";
-        process.stdout.write('Use Ctrl-D to stop input:\n> ');
         stdin.resume();
         stdin.on('data', function(chunk) {
             lines += chunk.toString();


### PR DESCRIPTION
Makes read/writes async and also adds some error checking.

Now for CLI if:
'-i' is specified without a parameter it defaults to stdin, if it is omitted no input is assumed.
'-o' is specified without parameter or omitted then defaults to stdout
'-g' is specified without a parameter or omitted defaults to stdin, (and if both input and grammar are from stdin then they are accepted in sequence, first grammar is input then 'input' )

I have tested it generally but this should be further tested by someone who can def verify output is correct.

Feedback/more testing/changes/hate/love welcome
