### PR TITLE
Fixed RegExp clone

### DIFF
--- a/LanguageVisualizer/parser.js
+++ b/LanguageVisualizer/parser.js
@@ -127,7 +127,10 @@ function evaluate(context, parent, rules, rule_id)
             var character = context.input.charAt(context.position);
 
             if (typeof rule[1] !== "function")
-                rule[1] = new RegExp(rule[1], "g");
+            {
+                rule[1] = new RegExp(rule[1]);
+                rule[1].global = true;
+            }
 
             if (character.match(rule[1]))
             {

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -120,7 +120,10 @@ function evaluate(context, parent, rules, rule_id)
             var character = context.input.charAt(context.position);
 
             if (typeof rule[1] !== "function")
-                rule[1] = new RegExp(rule[1], "g");
+            {
+                rule[1] = new RegExp(rule[1]);
+                rule[1].global = true;
+            }
 
             if (character.match(rule[1]))
             {


### PR DESCRIPTION
Safari doesn't like specifying flags when cloning a RegExp.
