### PR TITLE
Check if exitedNode is defined before calling

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -356,7 +356,9 @@ SyntaxNode.prototype.traverse = function(walker)
             else if (walker.traversesTextNodes)
             {
                 walker.enteredNode(child);
-                walker.exitedNode(child);
+
+                if (walker.exitedNode)
+                    walker.exitedNode(child);
             }
         }
     }


### PR DESCRIPTION
The parser should not require exitedNode to be defined when
traversing text nodes so we need to check if exitedNode
exists before calling it in a text node.
